### PR TITLE
cleans up a path

### DIFF
--- a/code/_globalvars/special_traits/traits.dm
+++ b/code/_globalvars/special_traits/traits.dm
@@ -76,13 +76,13 @@
 	ADD_TRAIT(character, TRAIT_NOMOOD, "[type]")
 	ADD_TRAIT(character, TRAIT_NOSTINK, "[type]")
 
-/datum/special_trait/latentmagic
-	name = "Latent Magic"
-	greet_text = span_notice("I have innate magical potential.")
-	weight = 25
+// /datum/special_trait/latentmagic
+// 	name = "Latent Magic"
+// 	greet_text = span_notice("I have innate magical potential.")
+// 	weight = 25
 
-/datum/special_trait/latentmagic/on_apply(mob/living/carbon/human/character, silent)
-	character.adjust_skillrank(/datum/skill/magic/arcane, 1, TRUE)
+// /datum/special_trait/latentmagic/on_apply(mob/living/carbon/human/character, silent)
+// 	character.adjust_skillrank(/datum/skill/magic/arcane, 1, TRUE)
 
 /datum/special_trait/value
 	name = "Coin Counter"
@@ -565,20 +565,20 @@
 	allowed_jobs = list(/datum/job/lord)
 	weight = 25 //Should be fine.
 
-/datum/special_trait/thinker/on_apply(mob/living/carbon/human/character, silent)
-	character.change_stat("strength", -3)
-	character.change_stat("intelligence", 6)
-	character.change_stat("constitution", -1)
-	character.change_stat("endurance", -1)
-	character.adjust_skillrank(/datum/skill/magic/arcane, 5, TRUE)
-	character.set_skillrank(/datum/skill/combat/swords, 2, TRUE) //Average only.
-	character.mind.adjust_spellpoints(14) //Less points than Court Mage, why do Court mage get 17 points? what even?
-	character.mind.AddSpell(new /obj/effect/proc_holder/spell/self/learnspell)
-	character.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
-	character.generate_random_attunements(rand(4,6))
-	character.mana_pool.set_intrinsic_recharge(MANA_ALL_LEYLINES)
-	character.mana_pool.adjust_mana(100) //I don't know, they don't spawn with their full mana bar, so we give them a bit more mana at the start.
-	new /obj/item/book/granter/spellbook/master(get_turf(character))
+// /datum/special_trait/thinker/on_apply(mob/living/carbon/human/character, silent)
+// 	character.change_stat("strength", -3)
+// 	character.change_stat("intelligence", 6)
+// 	character.change_stat("constitution", -1)
+// 	character.change_stat("endurance", -1)
+// 	character.adjust_skillrank(/datum/skill/magic/arcane, 5, TRUE)
+// 	character.set_skillrank(/datum/skill/combat/swords, 2, TRUE) //Average only.
+// 	character.mind.adjust_spellpoints(14) //Less points than Court Mage, why do Court mage get 17 points? what even?
+// 	character.mind.AddSpell(new /obj/effect/proc_holder/spell/self/learnspell)
+// 	character.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
+// 	character.generate_random_attunements(rand(4,6))
+// 	character.mana_pool.set_intrinsic_recharge(MANA_ALL_LEYLINES)
+// 	character.mana_pool.adjust_mana(100) //I don't know, they don't spawn with their full mana bar, so we give them a bit more mana at the start.
+// 	new /obj/item/book/granter/spellbook/master(get_turf(character))
 
 /datum/special_trait/skeleton
 	name = "Skeleton"

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -1791,25 +1791,6 @@
 	icon = 'icons/mob/rogueheat.dmi'
 	screen_loc = mana_loc
 
-/atom/movable/screen/mana/extra_info(mob/user)
-	var/info = ""
-	for(var/datum/attunement/attunement as anything in user?.mana_pool.attunements)
-		var/value = user.mana_pool.attunements[attunement]
-		if(!value)
-			continue
-
-		switch(value)
-			if(0.01 to 0.4)
-				info += "<br> Minor [initial(attunement.name)] Attunment"
-			if(0.41 to 0.7)
-				info += "<br> Moderate [initial(attunement.name)] Attunment"
-			if(0.71 to 1.2)
-				info += "<br> Major [initial(attunement.name)] Attunment"
-			if(1.21 to INFINITY)
-				info += "<br> Apex [initial(attunement.name)] Attunment"
-
-	return info
-
 /atom/movable/screen/stamina
 	name = "stamina"
 	icon_state = "fat100"

--- a/code/datums/mana/living_mana.dm
+++ b/code/datums/mana/living_mana.dm
@@ -74,15 +74,6 @@
 /mob/living/carbon/get_initial_mana_pool_type()
 	return /datum/mana_pool/mob
 
-/mob/living/carbon/proc/generate_random_attunements(amount = rand(2, 3))
-	var/list/attunements = subtypesof(/datum/attunement)
-	for(var/i = 1 to amount)
-		var/datum/attunement/picked = pick(attunements)
-		mana_pool?.adjust_attunement(picked, rand(1, 3) * 0.1)
-
-/mob/living/carbon/after_manapool_init()
-	generate_random_attunements()
-
 /mob/living/carbon/human/dummy
 	has_initial_mana_pool = FALSE
 

--- a/code/datums/rituals/ritual_runes.dm
+++ b/code/datums/rituals/ritual_runes.dm
@@ -822,35 +822,5 @@ GLOBAL_LIST(teleport_runes)
 		return
 	. = ..()
 
-/obj/effect/decal/cleanable/roguerune/arcyne/attunement
-	name = "arcyne attunement matrix"
-	desc = "A large matrix designed to imbue the energies of materials."
-	icon = 'icons/effects/160x160.dmi'
-	icon_state = "imbuement"
-	tier = 2
-	req_invokers = 2
-	invocation = "Xel’thix un’oral!"
-	ritual_number = FALSE
-	req_keyword = TRUE
-	runesize = 2
-	pixel_x = -64 //So the big ol' 96x96 sprite shows up right
-	pixel_y = -64
-	pixel_z = 0
-	can_be_scribed = TRUE
-	associated_ritual = /datum/runerituals/attunement
-	takes_all_items = TRUE
-
-/obj/effect/decal/cleanable/roguerune/arcyne/attunement/invoke(list/invokers, datum/runerituals/runeritual)
-	runeritual = associated_ritual
-	if(!..())	//VERY important. Calls parent and checks if it fails. parent/invoke has all the checks for ingredients
-		return
-	var/mob/living/user = invokers[1] //the first invoker is always the user
-	var/datum/runerituals/attunement/attune_ritual = pickritual
-
-	var/list/attunements = attune_ritual.attunement_modifiers
-
-	for(var/datum/attunement/attunement as anything in attunements)
-		user.mana_pool?.adjust_attunement(attunement, attunements[attunement])
-
 	pickritual.cleanup_atoms(selected_atoms)
 	do_invoke_glow()

--- a/code/modules/crafting/quality_of_crafting/books.dm
+++ b/code/modules/crafting/quality_of_crafting/books.dm
@@ -768,7 +768,6 @@
 
 	types = list(
 		/datum/book_entry/grimoire,
-		/datum/book_entry/attunement,
 		/datum/book_entry/mana_sources,
 		/datum/repeatable_crafting_recipe/arcyne,
 		/datum/slapcraft_recipe/arcyne,

--- a/code/modules/jobs/job_types/apprentices/wapprentice.dm
+++ b/code/modules/jobs/job_types/apprentices/wapprentice.dm
@@ -15,6 +15,7 @@
 	allowed_races = RACES_PLAYER_ALL
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_ages = list(AGE_CHILD, AGE_ADULT)
+	allowed_patrons = list(/datum/patron/divine/noc, /datum/patron/inhumen/zizo)
 
 
 	outfit = /datum/outfit/job/wapprentice

--- a/code/modules/jobs/job_types/nobility/magician.dm
+++ b/code/modules/jobs/job_types/nobility/magician.dm
@@ -81,5 +81,3 @@
 	H.mind?.AddSpell(new /obj/effect/proc_holder/spell/targeted/ethereal_jaunt)
 	H.mind?.AddSpell(new /obj/effect/proc_holder/spell/self/learnspell)
 	H.mind?.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
-
-	H?.generate_random_attunements(rand(4,6))

--- a/code/modules/mob/living/stats.dm
+++ b/code/modules/mob/living/stats.dm
@@ -52,10 +52,8 @@
 		return FALSE
 	if(patron && !ispath(patron))
 		patron.on_remove(src)
-		mana_pool?.remove_attunements(patron)
 	patron = new_patron
 	patron.on_gain(src)
-	mana_pool?.set_attunements(patron)
 	return TRUE
 
 ///Rolls random stats base 10, +-1, for SPECIAL, and applies species stats and age stats.

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -642,7 +642,7 @@
 			if(istype(ranged_ability, /obj/effect/proc_holder/spell))
 				var/obj/effect/proc_holder/spell/ability = ranged_ability
 				if(!ability.miracle && ability.uses_mana)
-					mmb_intent.AddComponent(/datum/component/uses_mana/spell,CALLBACK(mmb_intent, TYPE_PROC_REF(/datum/intent, spell_cannot_activate)),CALLBACK(mmb_intent, TYPE_PROC_REF(/datum/intent, get_owner)),COMSIG_SPELL_BEFORE_CAST,null,COMSIG_SPELL_AFTER_CAST,CALLBACK(ranged_ability, TYPE_PROC_REF(/obj/effect/proc_holder, get_fatigue_drain)),ranged_ability.attunements)
+					mmb_intent.AddComponent(/datum/component/uses_mana/spell,CALLBACK(mmb_intent, TYPE_PROC_REF(/datum/intent, spell_cannot_activate)),CALLBACK(mmb_intent, TYPE_PROC_REF(/datum/intent, get_owner)),COMSIG_SPELL_BEFORE_CAST,null,COMSIG_SPELL_AFTER_CAST,CALLBACK(ranged_ability, TYPE_PROC_REF(/obj/effect/proc_holder, get_fatigue_drain)),ranged_ability)
 
 
 	hud_used.quad_intents?.switch_intent(input)

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -27,9 +27,6 @@
 	var/obj/inhand_requirement = null
 	var/overlay_state = null
 
-	var/list/attunements
-	var/attuned_strength = 1
-
 /obj/effect/proc_holder/Initialize()
 	. = ..()
 	if(has_action)
@@ -389,18 +386,6 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 			charge_counter = recharge_time
 			recharging = FALSE
 
-/obj/effect/proc_holder/spell/proc/set_attuned_strength(list/incoming_attunements)
-	var/total_value = 1
-	for(var/datum/attunement/attunement as anything in attunements)
-		if(!(attunement in incoming_attunements))
-			continue
-		if(attunements[attunement] < 0)
-			total_value += incoming_attunements[attunement] + attunements[attunement]
-		else
-			total_value += incoming_attunements[attunement] - attunements[attunement]
-	attuned_strength = total_value
-	return
-
 /obj/effect/proc_holder/spell/proc/perform(list/targets, recharge = TRUE, mob/user = usr) //if recharge is started is important for the trigger spells
 	if(length(targets) && miracle && healing_miracle)
 		var/mob/living/target = targets[1]
@@ -421,15 +406,6 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 	if (!isnull(user.mana_pool))
 		usable_pools += user.mana_pool
 
-	var/list/total_attunements = GLOB.default_attunements.Copy()
-
-	for(var/datum/mana_pool/pool as anything in usable_pools)
-		for(var/negative_attunement in pool.negative_attunements)
-			total_attunements[negative_attunement] += pool.negative_attunements[negative_attunement]
-		for(var/attunement in pool.attunements)
-			total_attunements[attunement] += pool.attunements[attunement]
-
-	set_attuned_strength(total_attunements)
 	if(user && user.ckey)
 		create_logs(user, targets)
 	if(recharge)

--- a/code/modules/spells/spell_types/blindness.dm
+++ b/code/modules/spells/spell_types/blindness.dm
@@ -13,9 +13,6 @@
 	antimagic_allowed = TRUE
 	recharge_time = 2 MINUTES
 	associated_skill = /datum/skill/magic/arcane
-	attunements = list(
-		/datum/attunement/arcyne = 0.1
-		)
 
 /obj/effect/proc_holder/spell/invoked/blindness/cast(list/targets, mob/user = usr)
 	if(isliving(targets[1]))

--- a/code/modules/spells/spell_types/ethereal_jaunt.dm
+++ b/code/modules/spells/spell_types/ethereal_jaunt.dm
@@ -15,9 +15,6 @@
 	var/jaunt_in_type = /obj/effect/temp_visual/wizard
 	var/jaunt_out_type = /obj/effect/temp_visual/wizard/out
 	associated_skill = /datum/skill/magic/arcane
-	attunements = list(
-		/datum/attunement/arcyne = 0.4,
-	)
 
 /obj/effect/proc_holder/spell/targeted/ethereal_jaunt/cast(list/targets,mob/user = usr) //magnets, so mostly hardcoded
 	. = ..()

--- a/code/modules/spells/spell_types/invoked/acolyte/dendor.dm
+++ b/code/modules/spells/spell_types/invoked/acolyte/dendor.dm
@@ -22,10 +22,6 @@
 	invocation_type = "shout" //can be none, whisper, emote and shout
 	miracle = TRUE
 	devotion_cost = 15
-	attunements = list(
-		/datum/attunement/earth = 0.5,
-		/datum/attunement/life = 0.5,
-	)
 
 /obj/effect/proc_holder/spell/targeted/blesscrop/cast(list/targets,mob/user = usr)
 	. = ..()
@@ -59,9 +55,6 @@
 	releasedrain = 30
 	miracle = TRUE
 	devotion_cost = 15
-	attunements = list(
-		/datum/attunement/earth = 0.5,
-	)
 
 /obj/effect/proc_holder/spell/self/beastsense/cast(list/targets,mob/living/user = usr)
 	playsound(get_turf(user), 'sound/vo/smokedrag.ogg', 100, TRUE)
@@ -96,9 +89,7 @@
 	invocation_type = "whisper" //can be none, whisper, emote and shout
 	miracle = TRUE
 	devotion_cost = 60
-	attunements = list(
-		/datum/attunement/earth = 1,
-	)
+
 	var/static/list/pet_commands = list(
 		/datum/pet_command/idle,
 		/datum/pet_command/free,
@@ -256,9 +247,7 @@
 	req_items = list(/obj/item/clothing/neck/psycross/silver/dendor)
 	invocation = "Treefather light the way."
 	invocation_type = "whisper" //can be none, whisper, emote and shout
-	attunements = list(
-		/datum/attunement/earth = 0.6,
-	)
+
 	miracle = TRUE
 
 /obj/effect/proc_holder/spell/targeted/conjure_kneestingers/cast(list/targets,mob/user = usr)
@@ -293,10 +282,6 @@
 	releasedrain = 100
 	miracle = TRUE
 	devotion_cost = 100
-	attunements = list(
-		/datum/attunement/earth = 0.7,
-		/datum/attunement/polymorph = 0.5,
-	)
 
 /obj/effect/proc_holder/spell/self/trollshape/cast(list/targets,mob/living/user = usr)
 	. = ..()

--- a/code/modules/spells/spell_types/invoked/necromancer.dm
+++ b/code/modules/spells/spell_types/invoked/necromancer.dm
@@ -12,10 +12,6 @@
 	antimagic_allowed = TRUE
 	recharge_time = 15 SECONDS
 	miracle = FALSE
-	attunements = list(
-		/datum/attunement/dark = 0.4,
-		/datum/attunement/death = 0.5,
-	)
 
 /obj/effect/proc_holder/spell/invoked/strengthen_undead/cast(list/targets, mob/living/user)
 	. = ..()
@@ -52,9 +48,6 @@
 	antimagic_allowed = TRUE
 	recharge_time = 15 SECONDS
 	miracle = FALSE
-	attunements = list(
-		/datum/attunement/dark = 0.4,
-	)
 
 /obj/effect/proc_holder/spell/invoked/eyebite/cast(list/targets, mob/living/user)
 	. = ..()
@@ -81,11 +74,6 @@
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/arcane
 	recharge_time = 30 SECONDS
-	attunements = list(
-		/datum/attunement/dark = 0.4,
-		/datum/attunement/death = 1,
-	)
-
 
 /**
  * Raises a minion from a corpse. Prioritizing ownership to original player > ghosts > npc.
@@ -256,10 +244,6 @@
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/arcane
 	recharge_time = 15 SECONDS
-	attunements = list(
-		/datum/attunement/dark = 0.4,
-		/datum/attunement/blood = 0.5,
-	)
 
 /obj/effect/proc_holder/spell/self/command_undead
 	name = "Command Undead"

--- a/code/modules/spells/spell_types/invoked/vampire.dm
+++ b/code/modules/spells/spell_types/invoked/vampire.dm
@@ -7,10 +7,6 @@
 	cooldown_min = 50
 	die_with_shapeshifted_form =  FALSE
 	shapeshift_type = /mob/living/simple_animal/hostile/retaliate/bat
-	attunements = list(
-		/datum/attunement/dark = 0.4,
-		/datum/attunement/polymorph = 0.5,
-	)
 
 /obj/effect/proc_holder/spell/targeted/shapeshift/gaseousform
 	name = "Mist Form"
@@ -20,11 +16,6 @@
 	cooldown_min = 50
 	die_with_shapeshifted_form =  FALSE
 	shapeshift_type = /mob/living/simple_animal/hostile/retaliate/gaseousform
-	attunements = list(
-		/datum/attunement/dark = 0.4,
-		/datum/attunement/polymorph = 0.5,
-		/datum/attunement/aeromancy = 0.3,
-	)
 
 /obj/effect/proc_holder/spell/targeted/mansion_portal
 	name = "Mansion Portal"

--- a/code/modules/spells/spell_types/knock.dm
+++ b/code/modules/spells/spell_types/knock.dm
@@ -10,9 +10,6 @@
 	invocation_type = "whisper"
 	range = 3
 	cooldown_min = 0.5 MINUTES //20 deciseconds reduction per rank
-	attunements = list(
-		/datum/attunement/aeromancy = 0.2,
-	)
 
 /obj/effect/proc_holder/spell/aoe_turf/knock/cast(list/targets,mob/user = usr)
 //	SEND_SOUND(user, sound('sound/blank.ogg'))

--- a/code/modules/spells/spell_types/wizard/buffs/arcyne_eye.dm
+++ b/code/modules/spells/spell_types/wizard/buffs/arcyne_eye.dm
@@ -11,16 +11,12 @@
 	movement_interrupt = TRUE
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/arcane
-	attunements = list(
-		/datum/attunement/arcyne = 0.1
-		)
 	cost = 1
 	overlay_state = "transfix"
 
 /obj/effect/proc_holder/spell/self/arcyne_eye/cast(list/targets, mob/living/user)
 	playsound(get_turf(user), 'sound/vo/smokedrag.ogg', 100, TRUE)
-	var/duration_increase = min(0, attuned_strength * 1.5 MINUTES)
-	user.apply_status_effect(/datum/status_effect/buff/duration_modification/arcyne_eye, duration_increase)
+	user.apply_status_effect(/datum/status_effect/buff/duration_modification/arcyne_eye,)
 	return TRUE
 
 /datum/status_effect/buff/duration_modification/arcyne_eye

--- a/code/modules/spells/spell_types/wizard/buffs/bladeward.dm
+++ b/code/modules/spells/spell_types/wizard/buffs/bladeward.dm
@@ -24,23 +24,12 @@
 	invocation = "Blades, be dulled!"
 	invocation_type = "shout" //can be none, whisper, emote and shout
 
-	attunements = list(
-		/datum/attunement/arcyne = 0.3,
-	)
 // Notes: Bard, Sorcerer, Warlock, Wizard
 
 /obj/effect/proc_holder/spell/self/bladeward5e/cast(mob/user = usr)
 	var/mob/living/target = user
-	var/duration_increase = min(0, attuned_strength * 1.5 MINUTES)
-	target.apply_status_effect(/datum/status_effect/buff/duration_modification/bladeward5e, duration_increase)
+	target.apply_status_effect(/datum/status_effect/buff/duration_modification/bladeward5e)
 	user.visible_message("<span class='info'>[user] traces a warding sigil in the air.</span>", "<span class='notice'>I trace a a sigil of warding in the air.</span>")
-
-	if(attuned_strength > 1.5)
-		for(var/mob/living/extra_target in range(FLOOR(attuned_strength, 1)))
-			if(extra_target == target)
-				continue
-			extra_target.apply_status_effect(/datum/status_effect/buff/duration_modification/bladeward5e, duration_increase)
-			extra_target.visible_message("<span class='info'>[extra_target] has a sigil of warding appear over them.</span>", "<span class='notice'>I see a sigil of warding floating over me.</span>")
 
 	return TRUE
 

--- a/code/modules/spells/spell_types/wizard/buffs/darkvision.dm
+++ b/code/modules/spells/spell_types/wizard/buffs/darkvision.dm
@@ -9,13 +9,6 @@
 	associated_skill = /datum/skill/magic/arcane
 	hand_path = /obj/item/melee/touch_attack/darkvision
 	cost = 2
-	attunements = list(
-		/datum/attunement/light = 0.6,
-	)
-
-/obj/effect/proc_holder/spell/targeted/touch/darkvision/adjust_hand_charges()
-	var/increase = FLOOR(attuned_strength * 1.5, 1)
-	attached_hand.charges += increase
 
 /obj/item/melee/touch_attack/darkvision
 	name = "\improper arcyne focus"
@@ -35,8 +28,6 @@
 		var/mob/living/spelltarget = target
 		if(!do_after(user, 5 SECONDS, spelltarget))
 			return
-		var/duration_increase = min(0, attached_spell.attuned_strength * 2 MINUTES)
-		spelltarget.apply_status_effect(/datum/status_effect/buff/duration_modification/darkvision, duration_increase)
 		user.adjust_stamina(80)
 		if(spelltarget != user)
 			user.visible_message("[user] draws a glyph in the air and touches [spelltarget] with an arcyne focus.")

--- a/code/modules/spells/spell_types/wizard/buffs/darkvision.dm
+++ b/code/modules/spells/spell_types/wizard/buffs/darkvision.dm
@@ -28,6 +28,7 @@
 		var/mob/living/spelltarget = target
 		if(!do_after(user, 5 SECONDS, spelltarget))
 			return
+		spelltarget.apply_status_effect(/datum/status_effect/buff/duration_modification/darkvision,)
 		user.adjust_stamina(80)
 		if(spelltarget != user)
 			user.visible_message("[user] draws a glyph in the air and touches [spelltarget] with an arcyne focus.")

--- a/code/modules/spells/spell_types/wizard/buffs/featherfall.dm
+++ b/code/modules/spells/spell_types/wizard/buffs/featherfall.dm
@@ -14,15 +14,11 @@
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/arcane
 	overlay_state = "jump"
-	attunements = list(
-		/datum/attunement/aeromancy = 0.5,
-	)
 
 /obj/effect/proc_holder/spell/invoked/featherfall/cast(list/targets, mob/user = usr)
 
 	user.visible_message("[user] mutters an incantation and a dim pulse of light radiates out from them.")
-	var/duration_increase = min(0, attuned_strength * 90 SECONDS)
-	for(var/mob/living/L in range(max(1, FLOOR(attuned_strength, 1)), usr))
-		L.apply_status_effect(/datum/status_effect/buff/duration_modification/featherfall, duration_increase)
+	for(var/mob/living/L in range(max(1), usr))
+		L.apply_status_effect(/datum/status_effect/buff/duration_modification/featherfall,)
 
 	return TRUE

--- a/code/modules/spells/spell_types/wizard/buffs/featherfall.dm
+++ b/code/modules/spells/spell_types/wizard/buffs/featherfall.dm
@@ -18,7 +18,7 @@
 /obj/effect/proc_holder/spell/invoked/featherfall/cast(list/targets, mob/user = usr)
 
 	user.visible_message("[user] mutters an incantation and a dim pulse of light radiates out from them.")
-	for(var/mob/living/L in range(max(1), usr))
+	for(var/mob/living/L in range(1, usr))
 		L.apply_status_effect(/datum/status_effect/buff/duration_modification/featherfall,)
 
 	return TRUE

--- a/code/modules/spells/spell_types/wizard/buffs/guidance.dm
+++ b/code/modules/spells/spell_types/wizard/buffs/guidance.dm
@@ -14,9 +14,7 @@
 	charging_slowdown = 2
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/arcane
-	attunements = list(
-		/datum/attunement/arcyne = 1,
-	)
+
 
 /obj/effect/proc_holder/spell/invoked/guidance/cast(list/targets, mob/user)
 	var/atom/A = targets[1]
@@ -25,8 +23,6 @@
 
 	var/mob/living/spelltarget = A
 
-	var/duration_increase = min(0, attuned_strength * 60 SECONDS) //basically 1 minute extra per 1 attunement level since its a strong effect
-	spelltarget.apply_status_effect(/datum/status_effect/buff/duration_modification/guidance, duration_increase)
 	playsound(get_turf(spelltarget), 'sound/magic/haste.ogg', 80, TRUE, soundping = TRUE)
 
 	if(spelltarget != user)

--- a/code/modules/spells/spell_types/wizard/buffs/haste.dm
+++ b/code/modules/spells/spell_types/wizard/buffs/haste.dm
@@ -13,9 +13,6 @@
 	charging_slowdown = 2
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/arcane
-	attunements = list(
-		/datum/attunement/aeromancy = 0.5,
-	)
 
 /obj/effect/proc_holder/spell/invoked/haste/cast(list/targets, mob/user)
 	var/atom/A = targets[1]
@@ -24,8 +21,7 @@
 		return
 
 	var/mob/living/spelltarget = A
-	var/duration_increase = min(0, attuned_strength * 30 SECONDS)
-	spelltarget.apply_status_effect(/datum/status_effect/buff/duration_modification/haste, duration_increase)
+	spelltarget.apply_status_effect(/datum/status_effect/buff/duration_modification/haste,)
 	playsound(get_turf(spelltarget), 'sound/magic/haste.ogg', 80, TRUE, soundping = TRUE)
 
 	if(spelltarget != user)

--- a/code/modules/spells/spell_types/wizard/buffs/longstrider.dm
+++ b/code/modules/spells/spell_types/wizard/buffs/longstrider.dm
@@ -12,22 +12,15 @@
 	charging_slowdown = 1
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/arcane
-	attunements = list(
-		/datum/attunement/aeromancy = 0.8,
-	)
 
 /obj/effect/proc_holder/spell/invoked/longstrider/cast(list/targets, mob/user = usr)
 	. = ..()
 	user.visible_message("[user] mutters an incantation and a dim pulse of light radiates out from them.")
 
-	var/duration_increase = min(0, attuned_strength * 2 MINUTES)
-	for(var/mob/living/L in range(1, usr))
-		L.apply_status_effect(/datum/status_effect/buff/duration_modification/longstrider, duration_increase)
-
 /datum/status_effect/buff/duration_modification/longstrider
 	id = "longstrider"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/longstrider
-	duration = 5 MINUTES
+	duration = 6 MINUTES
 
 /datum/status_effect/buff/duration_modification/longstrider/on_apply()
 	. = ..()

--- a/code/modules/spells/spell_types/wizard/buffs/nondetection.dm
+++ b/code/modules/spells/spell_types/wizard/buffs/nondetection.dm
@@ -9,13 +9,6 @@
 	associated_skill = /datum/skill/magic/arcane
 	hand_path = /obj/item/melee/touch_attack/nondetection
 	cost = 1
-	attunements = list(
-		/datum/attunement/illusion = 0.4,
-	)
-
-/obj/effect/proc_holder/spell/targeted/touch/nondetection/adjust_hand_charges()
-	var/increase = FLOOR(attuned_strength * 1.5, 1)
-	attached_hand.charges += increase
 
 /obj/item/melee/touch_attack/nondetection
 	name = "\improper arcyne focus"

--- a/code/modules/spells/spell_types/wizard/buffs/primal_savagery.dm
+++ b/code/modules/spells/spell_types/wizard/buffs/primal_savagery.dm
@@ -20,10 +20,6 @@
 	associated_skill = /datum/skill/magic/druidic //can be arcane, druidic, blood, holy
 	cost = 1
 
-	attunements = list(
-		/datum/attunement/earth = 0.3,
-	)
-
 	miracle = FALSE
 
 	invocation = "Teeth of a serpent."
@@ -32,18 +28,9 @@
 
 /obj/effect/proc_holder/spell/self/primalsavagery5e/cast(mob/user = usr)
 	var/mob/living/target = user
-	var/duration_increase = min(0, attuned_strength * 1 MINUTES)
-	target.apply_status_effect(/datum/status_effect/buff/duration_increase/primalsavagery5e, duration_increase)
+	target.apply_status_effect(/datum/status_effect/buff/duration_increase/primalsavagery5e,)
 	ADD_TRAIT(target, TRAIT_POISONBITE, TRAIT_GENERIC)
 	user.visible_message(span_info("[user] looks more primal!"), span_info("You feel more primal."))
-
-	if(attuned_strength > 1.5)
-		for(var/mob/living/extra_target in range(FLOOR(attuned_strength, 1)))
-			if(extra_target == target)
-				continue
-			extra_target.apply_status_effect(/datum/status_effect/buff/duration_increase/primalsavagery5e, duration_increase)
-			ADD_TRAIT(extra_target, TRAIT_POISONBITE, TRAIT_GENERIC)
-			extra_target.visible_message(span_info("[extra_target] looks more primal!"), span_info("You feel more primal."))
 
 	return TRUE
 

--- a/code/modules/spells/spell_types/wizard/damage/acid_splash.dm
+++ b/code/modules/spells/spell_types/wizard/damage/acid_splash.dm
@@ -18,11 +18,7 @@
 	charging_slowdown = 3
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/arcane //can be arcane, druidic, blood, holy
-	cost = 1
-	attunements = list(
-		/datum/attunement/blood = 0.3,
-		/datum/attunement/death = 0.4,
-	)
+	cost = 2
 
 /obj/effect/proc_holder/spell/self/acidsplash5e/cast(mob/user = usr)
 	var/mob/living/target = user

--- a/code/modules/spells/spell_types/wizard/damage/arcane_bolt.dm
+++ b/code/modules/spells/spell_types/wizard/damage/arcane_bolt.dm
@@ -17,9 +17,6 @@
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/arcane
 	cost = 2
-	attunements = list(
-		/datum/attunement/arcyne = 0.7,
-	)
 
 /obj/projectile/energy/rogue3
 	name = "arcane bolt"

--- a/code/modules/spells/spell_types/wizard/damage/arcyne_storm.dm
+++ b/code/modules/spells/spell_types/wizard/damage/arcyne_storm.dm
@@ -2,7 +2,7 @@
 /obj/effect/proc_holder/spell/invoked/arcyne_storm
 	name = "Arcyne storm"
 	desc = "Conjure ripples of force into existance over a large area, injuring any who enter"
-	cost = 2
+	cost = 8
 	releasedrain = 50
 	chargedrain = 1
 	chargetime = 12 SECONDS
@@ -15,9 +15,6 @@
 	associated_skill = /datum/skill/magic/arcane
 	overlay_state = "hierophant"
 	range = 4
-	attunements = list(
-		/datum/attunement/arcyne = 1.2
-	)
 	var/damage = 10
 
 /obj/effect/proc_holder/spell/invoked/arcyne_storm/cast(list/targets, mob/user = usr)

--- a/code/modules/spells/spell_types/wizard/damage/blade_burst.dm
+++ b/code/modules/spells/spell_types/wizard/damage/blade_burst.dm
@@ -13,9 +13,6 @@
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/arcane
 	overlay_state = "blade_burst"
-	attunements = list(
-		/datum/attunement/earth = 0.4,
-	)
 	var/delay = 7
 	var/damage = 45
 

--- a/code/modules/spells/spell_types/wizard/damage/blood_lightning.dm
+++ b/code/modules/spells/spell_types/wizard/damage/blood_lightning.dm
@@ -16,10 +16,6 @@
 	charging_slowdown = 3
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/blood
-	attunements = list(
-		/datum/attunement/electric = 0.3,
-		/datum/attunement/blood = 0.7,
-	)
 
 /obj/projectile/magic/bloodlightning
 	name = "blood bolt"

--- a/code/modules/spells/spell_types/wizard/damage/blood_steal.dm
+++ b/code/modules/spells/spell_types/wizard/damage/blood_steal.dm
@@ -15,9 +15,6 @@
 	charging_slowdown = 3
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/blood
-	attunements = list(
-		/datum/attunement/blood = 0.7,
-	)
 
 /obj/projectile/magic/bloodsteal
 	name = "blood steal"

--- a/code/modules/spells/spell_types/wizard/damage/booming_blade.dm
+++ b/code/modules/spells/spell_types/wizard/damage/booming_blade.dm
@@ -1,6 +1,6 @@
 /obj/effect/proc_holder/spell/invoked/boomingblade5e
 	name = "Booming Blade"
-	desc = "Causes explosions to ripple out from your target when they move."
+	desc = "A spell which uses a weapon as a focus. Causes the target to endure a blinding explosion upon movement."
 	overlay_state = "blade_burst"
 	releasedrain = 50
 	chargetime = 3

--- a/code/modules/spells/spell_types/wizard/damage/booming_blade.dm
+++ b/code/modules/spells/spell_types/wizard/damage/booming_blade.dm
@@ -23,9 +23,6 @@
 	invocation = "Stay still!" // Incantation should explain a confusing spell's mechanic.
 	invocation_type = "shout" //can be none, whisper, emote and shout
 
-	attunements = list(
-		/datum/attunement/earth = 0.3,
-	)
 
 /obj/effect/proc_holder/spell/invoked/boomingblade5e/cast(list/targets, mob/living/user)
 	if(isliving(targets[1]))

--- a/code/modules/spells/spell_types/wizard/damage/eldritch_blast.dm
+++ b/code/modules/spells/spell_types/wizard/damage/eldritch_blast.dm
@@ -26,9 +26,6 @@
 	invocation = "Eldritch blast!" // Bad incantation but it's funny.
 	invocation_type = "shout"
 
-	attunements = list(
-		/datum/attunement/dark = 0.3,
-	)
 
 
 /obj/projectile/magic/eldritchblast5e

--- a/code/modules/spells/spell_types/wizard/damage/fireball.dm
+++ b/code/modules/spells/spell_types/wizard/damage/fireball.dm
@@ -15,9 +15,6 @@
 	movement_interrupt = TRUE
 	chargedloop = /datum/looping_sound/invokefire
 	associated_skill = /datum/skill/magic/arcane
-	attunements = list(
-		/datum/attunement/fire = 0.5
-		)
 	cost = 5
 
 /obj/projectile/magic/aoe/fireball/rogue

--- a/code/modules/spells/spell_types/wizard/damage/fireball.dm
+++ b/code/modules/spells/spell_types/wizard/damage/fireball.dm
@@ -18,7 +18,7 @@
 	attunements = list(
 		/datum/attunement/fire = 0.5
 		)
-	cost = 4
+	cost = 5
 
 /obj/projectile/magic/aoe/fireball/rogue
 	name = "fireball"

--- a/code/modules/spells/spell_types/wizard/damage/frostbolt.dm
+++ b/code/modules/spells/spell_types/wizard/damage/frostbolt.dm
@@ -19,10 +19,7 @@
 	charging_slowdown = 3
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/arcane //can be arcane, druidic, blood, holy
-	cost = 1
-	attunements = list(
-		/datum/attunement/ice = 0.7,
-	)
+	cost = 2
 
 /obj/effect/proc_holder/spell/self/frostbolt/cast(mob/user = usr)
 	var/mob/living/target = user

--- a/code/modules/spells/spell_types/wizard/damage/greater_fireball.dm
+++ b/code/modules/spells/spell_types/wizard/damage/greater_fireball.dm
@@ -15,9 +15,6 @@
 	movement_interrupt = TRUE
 	chargedloop = /datum/looping_sound/invokefire
 	cost = 10
-	attunements = list(
-		/datum/attunement/fire = 1.1,
-	)
 
 /obj/projectile/magic/aoe/fireball/rogue/great
 	name = "fireball"

--- a/code/modules/spells/spell_types/wizard/damage/greenflame_blade.dm
+++ b/code/modules/spells/spell_types/wizard/damage/greenflame_blade.dm
@@ -1,6 +1,6 @@
 /obj/effect/proc_holder/spell/invoked/greenflameblade5e
 	name = "Green-Flame Blade"
-	desc = "An attack that burns all in an aoe around your target."
+	desc = "A spell which uses a weapon as it's focus to scorch your target briefly."
 	overlay_state = "null"
 	releasedrain = 50
 	chargetime = 3

--- a/code/modules/spells/spell_types/wizard/damage/greenflame_blade.dm
+++ b/code/modules/spells/spell_types/wizard/damage/greenflame_blade.dm
@@ -22,10 +22,6 @@
 	invocation = "Green flame blade!"
 	invocation_type = "shout" //can be none, whisper, emote and shout
 
-	attunements = list(
-		/datum/attunement/fire = 0.3,
-	)
-
 /obj/effect/proc_holder/spell/invoked/greenflameblade5e/cast(list/targets, mob/living/user)
 	if(isliving(targets[1]))
 		var/mob/living/carbon/target = targets[1]

--- a/code/modules/spells/spell_types/wizard/damage/lightning_bolt.dm
+++ b/code/modules/spells/spell_types/wizard/damage/lightning_bolt.dm
@@ -18,7 +18,7 @@
 	associated_skill = /datum/skill/magic/arcane
 	sparks_spread = 3
 	sparks_amt = 5
-	cost = 3
+	cost = 6
 	attunements = list(
 		/datum/attunement/electric = 0.5,
 	)

--- a/code/modules/spells/spell_types/wizard/damage/lightning_bolt.dm
+++ b/code/modules/spells/spell_types/wizard/damage/lightning_bolt.dm
@@ -19,9 +19,6 @@
 	sparks_spread = 3
 	sparks_amt = 5
 	cost = 6
-	attunements = list(
-		/datum/attunement/electric = 0.5,
-	)
 
 /obj/projectile/magic/lightning
 	name = "bolt of lightning"

--- a/code/modules/spells/spell_types/wizard/damage/lightning_lure.dm
+++ b/code/modules/spells/spell_types/wizard/damage/lightning_lure.dm
@@ -13,16 +13,13 @@
 	sound = 'sound/magic/whiteflame.ogg'
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/arcane //can be arcane, druidic, blood, holy
-	cost = 2 // might even deserve a cost of 3
+	cost = 4 // might even deserve a cost of 3
 
 	miracle = FALSE
 
 	invocation = ""
 	invocation_type = "shout" //can be none, whisper, emote and shout
 	include_user = FALSE
-	attunements = list(
-		/datum/attunement/electric = 1.2
-	)
 
 	var/delay = 3 SECONDS
 	var/sprite_changes = 10

--- a/code/modules/spells/spell_types/wizard/damage/meteor.dm
+++ b/code/modules/spells/spell_types/wizard/damage/meteor.dm
@@ -12,9 +12,6 @@
 	charging_slowdown = 2
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/arcane
-	attunements = list(
-		/datum/attunement/fire = 1.2
-	)
 
 /obj/effect/proc_holder/spell/invoked/meteor_storm/cast(list/targets, mob/user = usr)
 	var/turf/T = get_turf(targets[1])
@@ -25,26 +22,13 @@
 		create_meteors(T)
 	return TRUE
 
-/obj/effect/proc_holder/spell/invoked/meteor_storm/set_attuned_strength(list/incoming_attunements)
-	var/total_value = 1
-	for(var/datum/attunement/attunement as anything in attunements)
-		if(istype(attunement, /datum/attunement/blood))
-			total_value -= incoming_attunements[attunement] * 0.5
-		if(!(attunement in incoming_attunements))
-			continue
-		total_value += incoming_attunements[attunement] - attunements[attunement]
-
-	attuned_strength = total_value
-	attuned_strength = max(attuned_strength, 0.5)
-	return
-
 //meteor storm and lightstorm.
 /obj/effect/proc_holder/spell/invoked/meteor_storm/proc/create_meteors(atom/target)
 	if(!target)
 		return
 	target.visible_message(span_boldwarning("Fire rains from the sky!"))
 	var/turf/targetturf = get_turf(target)
-	var/value = 20 * attuned_strength
+	var/value = 20
 	while(value > 0)
 		for(var/turf/turf as anything in RANGE_TURFS(6,targetturf))
 			if(prob(min(20, value)))

--- a/code/modules/spells/spell_types/wizard/damage/meteor.dm
+++ b/code/modules/spells/spell_types/wizard/damage/meteor.dm
@@ -2,10 +2,10 @@
 	name = "Meteor storm"
 	desc = "Summons forth dangerous meteors from the sky to scatter and smash foes."
 	cost = 8
-	releasedrain = 110
-	chargedrain = 1
+	releasedrain = 250
+	chargedrain = 20
 	chargetime = 25 SECONDS
-	recharge_time = 50 SECONDS
+	recharge_time = 100 SECONDS
 	warnie = "spellwarning"
 	no_early_release = TRUE
 	movement_interrupt = TRUE

--- a/code/modules/spells/spell_types/wizard/damage/mind_sliver.dm
+++ b/code/modules/spells/spell_types/wizard/damage/mind_sliver.dm
@@ -16,10 +16,6 @@
 	associated_skill = /datum/skill/magic/arcane //can be arcane, druidic, blood, holy
 	cost = 1
 
-	attunements = list(
-		/datum/attunement/dark = 0.5,
-	)
-
 	miracle = FALSE
 
 	invocation = "Steal their thoughts!"

--- a/code/modules/spells/spell_types/wizard/damage/ray_of_frost.dm
+++ b/code/modules/spells/spell_types/wizard/damage/ray_of_frost.dm
@@ -21,11 +21,6 @@
 	associated_skill = /datum/skill/magic/arcane //can be arcane, druidic, blood, holy
 	cost = 1
 
-
-	attunements = list(
-		/datum/attunement/ice = 0.6,
-	)
-
 	miracle = FALSE
 
 	invocation = "Chill!"

--- a/code/modules/spells/spell_types/wizard/damage/spitfire.dm
+++ b/code/modules/spells/spell_types/wizard/damage/spitfire.dm
@@ -17,9 +17,6 @@
 	chargedloop = /datum/looping_sound/invokefire
 	associated_skill = /datum/skill/magic/arcane
 	cost = 3
-	attunements = list(
-		/datum/attunement/fire = 0.3,
-	)
 
 /obj/projectile/magic/aoe/fireball/rogue2
 	name = "spitfire"

--- a/code/modules/spells/spell_types/wizard/damage/sundering_lightning.dm
+++ b/code/modules/spells/spell_types/wizard/damage/sundering_lightning.dm
@@ -13,9 +13,6 @@
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/arcane
 	range = 4
-	attunements = list(
-		/datum/attunement/electric = 0.9
-	)
 
 /obj/effect/proc_holder/spell/invoked/sundering_lightning/cast(list/targets, mob/user = usr)
 	var/turf/T = get_turf(targets[1])

--- a/code/modules/spells/spell_types/wizard/debuffs/decompose.dm
+++ b/code/modules/spells/spell_types/wizard/debuffs/decompose.dm
@@ -22,9 +22,6 @@
 
 	invocation = "Return to rot."
 	invocation_type = "whisper"
-	attunements = list(
-		/datum/attunement/death = 0.3,
-	)
 
 /obj/effect/proc_holder/spell/invoked/decompose5e/cast(list/targets, mob/living/user)
 	if(!isliving(targets[1]))

--- a/code/modules/spells/spell_types/wizard/debuffs/frostbite.dm
+++ b/code/modules/spells/spell_types/wizard/debuffs/frostbite.dm
@@ -21,9 +21,6 @@
 
 	invocation = ""
 	invocation_type = "shout" //can be none, whisper, emote and shout
-	attunements = list(
-		/datum/attunement/ice = 0.9
-	)
 
 /obj/effect/proc_holder/spell/invoked/frostbite5e/cast(list/targets, mob/living/user)
 	if(isliving(targets[1]))

--- a/code/modules/spells/spell_types/wizard/debuffs/gravity.dm
+++ b/code/modules/spells/spell_types/wizard/debuffs/gravity.dm
@@ -12,9 +12,7 @@
 	charging_slowdown = 2
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/arcane
-	attunements = list(
-		/datum/attunement/dark = 0.6,
-	)
+
 	var/delay = 3
 	var/damage = 0 // damage based off your str
 	var/area_of_effect = 0

--- a/code/modules/spells/spell_types/wizard/debuffs/infestation.dm
+++ b/code/modules/spells/spell_types/wizard/debuffs/infestation.dm
@@ -21,12 +21,6 @@
 	invocation = "Rot, take them!"
 	invocation_type = "shout" //can be none, whisper, emote and shout
 
-	attunements = list(
-		/datum/attunement/dark = 0.3,
-		/datum/attunement/death = 0.3,
-	)
-
-
 /obj/effect/proc_holder/spell/invoked/infestation5e/cast(list/targets, mob/living/user)
 	if(isliving(targets[1]))
 		var/mob/living/carbon/target = targets[1]

--- a/code/modules/spells/spell_types/wizard/debuffs/snapfreeze.dm
+++ b/code/modules/spells/spell_types/wizard/debuffs/snapfreeze.dm
@@ -15,10 +15,7 @@
 	charging_slowdown = 2
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/arcane
-	attunements = list(
-		/datum/attunement/blood = 0.3,
-		/datum/attunement/ice = 0.4,
-	)
+
 	var/delay = 3
 	var/damage = 50 // less then fireball, more then lighting bolt
 	var/area_of_effect = 2

--- a/code/modules/spells/spell_types/wizard/learn_spell.dm
+++ b/code/modules/spells/spell_types/wizard/learn_spell.dm
@@ -46,7 +46,6 @@
 		/obj/effect/proc_holder/spell/self/arcyne_eye,
 		/obj/effect/proc_holder/spell/invoked/chilltouch5e,
 		/obj/effect/proc_holder/spell/invoked/infestation5e,
-		/obj/effect/proc_holder/spell/invoked/magicstone5e,
 		/obj/effect/proc_holder/spell/invoked/decompose5e,
 		/obj/effect/proc_holder/spell/targeted/encodethoughts5e,
 		/obj/effect/proc_holder/spell/invoked/guidance,
@@ -63,6 +62,7 @@
 		// /obj/effect/proc_holder/spell/invoked/projectile/eldritchblast5e,
 		// /obj/effect/proc_holder/spell/invoked/mindsliver5e,
 		// /obj/effect/proc_holder/spell/self/primalsavagery5e,
+		// /obj/effect/proc_holder/spell/invoked/magicstone5e, //has anyone even fucking used this?
 	)
 
 	for(var/i = 1, i <= spell_choices.len, i++)

--- a/code/modules/spells/spell_types/wizard/learn_spell.dm
+++ b/code/modules/spells/spell_types/wizard/learn_spell.dm
@@ -26,42 +26,43 @@
 		/obj/effect/proc_holder/spell/invoked/frostbite5e,
 		/obj/effect/proc_holder/spell/invoked/snap_freeze,
 		/obj/effect/proc_holder/spell/invoked/projectile/acidsplash5e,
-		/obj/effect/proc_holder/spell/invoked/boomingblade5e,
 		/obj/effect/proc_holder/spell/invoked/greenflameblade5e,
-		/obj/effect/proc_holder/spell/invoked/poisonspray5e,
-		/obj/effect/proc_holder/spell/invoked/projectile/repel,
-		/obj/effect/proc_holder/spell/invoked/forcewall_weak,
-		/obj/effect/proc_holder/spell/invoked/slowdown_spell_aoe,
-		/obj/effect/proc_holder/spell/invoked/haste,
+		/obj/effect/proc_holder/spell/invoked/boomingblade5e,
+		/obj/effect/proc_holder/spell/invoked/chilltouch5e,
+		/obj/effect/proc_holder/spell/invoked/decompose5e,
 		/obj/effect/proc_holder/spell/invoked/findfamiliar,
+		//Status Spells
 		/obj/effect/proc_holder/spell/targeted/touch/darkvision,// 2 cost
-		/obj/effect/proc_holder/spell/self/message,
-		/obj/effect/proc_holder/spell/invoked/projectile/fetch,
 		/obj/effect/proc_holder/spell/targeted/touch/nondetection, // 1 cost
-		/obj/effect/proc_holder/spell/targeted/touch/prestidigitation,
-		/obj/effect/proc_holder/spell/invoked/featherfall,
-		/obj/effect/proc_holder/spell/invoked/gravity,
+		/obj/effect/proc_holder/spell/self/bladeward5e,
 		/obj/effect/proc_holder/spell/invoked/longstrider,
 		/obj/effect/proc_holder/spell/invoked/guidance,
+		/obj/effect/proc_holder/spell/invoked/featherfall,
+		/obj/effect/proc_holder/spell/invoked/slowdown_spell_aoe,
+		/obj/effect/proc_holder/spell/invoked/gravity,
+		/obj/effect/proc_holder/spell/invoked/haste,
+		//Utility spells
+		/obj/effect/proc_holder/spell/targeted/touch/prestidigitation,
+		/obj/effect/proc_holder/spell/invoked/projectile/repel,
+		/obj/effect/proc_holder/spell/invoked/push_spell,
+		/obj/effect/proc_holder/spell/invoked/projectile/fetch,
+		/obj/effect/proc_holder/spell/invoked/forcewall_weak,
+		/obj/effect/proc_holder/spell/invoked/poisonspray5e,
 		/obj/effect/proc_holder/spell/self/arcyne_eye,
-		/obj/effect/proc_holder/spell/invoked/chilltouch5e,
-		/obj/effect/proc_holder/spell/invoked/infestation5e,
-		/obj/effect/proc_holder/spell/invoked/decompose5e,
+		/obj/effect/proc_holder/spell/self/message,
 		/obj/effect/proc_holder/spell/targeted/encodethoughts5e,
-		/obj/effect/proc_holder/spell/invoked/guidance,
 		/obj/effect/proc_holder/spell/self/light5e,
-		/obj/effect/proc_holder/spell/self/bladeward5e,
 		/obj/effect/proc_holder/spell/aoe_turf/conjure/createbonfire5e,
 // Unused or unlearnable spells
 		// /obj/effect/proc_holder/spell/targeted/ethereal_jaunt, //locked to CM
 		// /obj/effect/proc_holder/spell/aoe_turf/knock, //locked to CM
 		// /obj/effect/proc_holder/spell/invoked/meteor_storm, //locked to CM
 		// /obj/effect/proc_holder/spell/invoked/projectile/bloodlightning, //antag only
-		// /obj/effect/proc_holder/spell/invoked/push_spell,
 		// /obj/effect/proc_holder/spell/invoked/projectile/rayoffrost5e,
 		// /obj/effect/proc_holder/spell/invoked/projectile/eldritchblast5e,
 		// /obj/effect/proc_holder/spell/invoked/mindsliver5e,
-		// /obj/effect/proc_holder/spell/self/primalsavagery5e,
+		// /obj/effect/proc_holder/spell/self/primalsavagery5e, //more of a druid spell. Moving to them.
+		// /obj/effect/proc_holder/spell/invoked/infestation5e, //ditto
 		// /obj/effect/proc_holder/spell/invoked/magicstone5e, //has anyone even fucking used this?
 	)
 

--- a/code/modules/spells/spell_types/wizard/learn_spell.dm
+++ b/code/modules/spells/spell_types/wizard/learn_spell.dm
@@ -17,6 +17,7 @@
 		//Offensive Spells: Organized by Elemental type (Please follow this!)
 		/obj/effect/proc_holder/spell/invoked/projectile/spitfire,
 		/obj/effect/proc_holder/spell/invoked/projectile/fireball,// 5 cost
+		/obj/effect/proc_holder/spell/targeted/lightninglure,
 		/obj/effect/proc_holder/spell/invoked/projectile/lightningbolt,// 6 cost
 		/obj/effect/proc_holder/spell/invoked/sundering_lightning,
 		/obj/effect/proc_holder/spell/invoked/projectile/arcanebolt,

--- a/code/modules/spells/spell_types/wizard/learn_spell.dm
+++ b/code/modules/spells/spell_types/wizard/learn_spell.dm
@@ -10,56 +10,59 @@
 /obj/effect/proc_holder/spell/self/learnspell/cast(list/targets, mob/user = usr)
 	. = ..()
 	//list of spells you can learn, it may be good to move this somewhere else eventually
+	//spells ported from azure are in modular_azure
 	//TODO: make GLOB list of spells, give them a true/false tag for learning, run through that list to generate choices
 	var/list/choices = list()
 	var/list/obj/effect/proc_holder/spell/spell_choices = list(
-		/obj/effect/proc_holder/spell/invoked/projectile/fireball,// 4 cost
-		/obj/effect/proc_holder/spell/invoked/projectile/lightningbolt,// 3 cost
+		//Offensive Spells: Organized by Elemental type (Please follow this!)
 		/obj/effect/proc_holder/spell/invoked/projectile/spitfire,
+		/obj/effect/proc_holder/spell/invoked/projectile/fireball,// 5 cost
+		/obj/effect/proc_holder/spell/invoked/projectile/lightningbolt,// 6 cost
+		/obj/effect/proc_holder/spell/invoked/sundering_lightning,
+		/obj/effect/proc_holder/spell/invoked/projectile/arcanebolt,
+		/obj/effect/proc_holder/spell/invoked/blade_burst,
+		/obj/effect/proc_holder/spell/invoked/arcyne_storm,
+		/obj/effect/proc_holder/spell/invoked/projectile/frostbolt,
+		/obj/effect/proc_holder/spell/invoked/frostbite5e,
+		/obj/effect/proc_holder/spell/invoked/snap_freeze,
+		/obj/effect/proc_holder/spell/invoked/projectile/acidsplash5e,
+		/obj/effect/proc_holder/spell/invoked/boomingblade5e,
+		/obj/effect/proc_holder/spell/invoked/greenflameblade5e,
+		/obj/effect/proc_holder/spell/invoked/poisonspray5e,
+		/obj/effect/proc_holder/spell/invoked/projectile/repel,
 		/obj/effect/proc_holder/spell/invoked/forcewall_weak,
 		/obj/effect/proc_holder/spell/invoked/slowdown_spell_aoe,
 		/obj/effect/proc_holder/spell/invoked/haste,
 		/obj/effect/proc_holder/spell/invoked/findfamiliar,
-		/obj/effect/proc_holder/spell/self/primalsavagery5e,
-		/obj/effect/proc_holder/spell/invoked/projectile/bloodlightning,
-//		/obj/effect/proc_holder/spell/invoked/push_spell,
-//		/obj/effect/proc_holder/spell/targeted/ethereal_jaunt,
-//		/obj/effect/proc_holder/spell/aoe_turf/knock,
 		/obj/effect/proc_holder/spell/targeted/touch/darkvision,// 2 cost
 		/obj/effect/proc_holder/spell/self/message,
-		/obj/effect/proc_holder/spell/invoked/blade_burst,
 		/obj/effect/proc_holder/spell/invoked/projectile/fetch,
-		/obj/effect/proc_holder/spell/invoked/projectile/arcanebolt,
 		/obj/effect/proc_holder/spell/targeted/touch/nondetection, // 1 cost
 		/obj/effect/proc_holder/spell/targeted/touch/prestidigitation,
 		/obj/effect/proc_holder/spell/invoked/featherfall,
-		/obj/effect/proc_holder/spell/invoked/projectile/acidsplash5e, //spells ported from azure in modular_azure
-		/obj/effect/proc_holder/spell/invoked/snap_freeze,
-		/obj/effect/proc_holder/spell/invoked/projectile/frostbolt,
 		/obj/effect/proc_holder/spell/invoked/gravity,
-		/obj/effect/proc_holder/spell/invoked/projectile/repel,
 		/obj/effect/proc_holder/spell/invoked/longstrider,
 		/obj/effect/proc_holder/spell/invoked/guidance,
 		/obj/effect/proc_holder/spell/self/arcyne_eye,
-		/obj/effect/proc_holder/spell/invoked/meteor_storm,
-		/obj/effect/proc_holder/spell/invoked/boomingblade5e,
-		/obj/effect/proc_holder/spell/invoked/arcyne_storm,
-		/obj/effect/proc_holder/spell/invoked/frostbite5e,
-		/obj/effect/proc_holder/spell/invoked/sundering_lightning,
-		/obj/effect/proc_holder/spell/invoked/poisonspray5e,
-		/obj/effect/proc_holder/spell/invoked/greenflameblade5e,
 		/obj/effect/proc_holder/spell/invoked/chilltouch5e,
 		/obj/effect/proc_holder/spell/invoked/infestation5e,
 		/obj/effect/proc_holder/spell/invoked/magicstone5e,
 		/obj/effect/proc_holder/spell/invoked/decompose5e,
 		/obj/effect/proc_holder/spell/targeted/encodethoughts5e,
-		/obj/effect/proc_holder/spell/invoked/mindsliver5e,
 		/obj/effect/proc_holder/spell/invoked/guidance,
 		/obj/effect/proc_holder/spell/self/light5e,
 		/obj/effect/proc_holder/spell/self/bladeward5e,
 		/obj/effect/proc_holder/spell/aoe_turf/conjure/createbonfire5e,
-		/obj/effect/proc_holder/spell/invoked/projectile/rayoffrost5e,
-		/obj/effect/proc_holder/spell/invoked/projectile/eldritchblast5e,
+// Unused or unlearnable spells
+		// /obj/effect/proc_holder/spell/targeted/ethereal_jaunt, //locked to CM
+		// /obj/effect/proc_holder/spell/aoe_turf/knock, //locked to CM
+		// /obj/effect/proc_holder/spell/invoked/meteor_storm, //locked to CM
+		// /obj/effect/proc_holder/spell/invoked/projectile/bloodlightning, //antag only
+		// /obj/effect/proc_holder/spell/invoked/push_spell,
+		// /obj/effect/proc_holder/spell/invoked/projectile/rayoffrost5e,
+		// /obj/effect/proc_holder/spell/invoked/projectile/eldritchblast5e,
+		// /obj/effect/proc_holder/spell/invoked/mindsliver5e,
+		// /obj/effect/proc_holder/spell/self/primalsavagery5e,
 	)
 
 	for(var/i = 1, i <= spell_choices.len, i++)

--- a/code/modules/spells/spell_types/wizard/summoning/find_familiar.dm
+++ b/code/modules/spells/spell_types/wizard/summoning/find_familiar.dm
@@ -16,9 +16,6 @@
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/arcane
 	cost = 3
-	attunements = list(
-		/datum/attunement/arcyne = 0.4,
-	)
 
 /obj/effect/proc_holder/spell/invoked/findfamiliar/cast(list/targets,mob/user = usr)
 	. = ..()

--- a/code/modules/spells/spell_types/wizard/utility/chill_touch.dm
+++ b/code/modules/spells/spell_types/wizard/utility/chill_touch.dm
@@ -13,18 +13,13 @@
 	sound = 'sound/magic/whiteflame.ogg'
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/arcane //can be arcane, druidic, blood, holy
-	cost = 1
+	cost = 4
 
 
 	miracle = FALSE
 
 	invocation = "Be torn apart!"
 	invocation_type = "shout"
-
-	attunements = list(
-		/datum/attunement/ice = 0.3,
-	)
-
 
 // Notes: sorcerer, warlock, wizard
 /obj/effect/proc_holder/spell/invoked/chilltouch5e/cast(list/targets, mob/living/user)

--- a/code/modules/spells/spell_types/wizard/utility/create_bonfire.dm
+++ b/code/modules/spells/spell_types/wizard/utility/create_bonfire.dm
@@ -32,9 +32,6 @@
 	summon_amt = 1
 
 	action_icon_state = "the_traps"
-	attunements = list(
-		/datum/attunement/fire = 0.3,
-	)
 
 /obj/machinery/light/fueled/campfire/createbonfire5e
 	name = "magical bonfire"

--- a/code/modules/spells/spell_types/wizard/utility/enchant_stone.dm
+++ b/code/modules/spells/spell_types/wizard/utility/enchant_stone.dm
@@ -17,10 +17,6 @@
 
 	miracle = FALSE
 
-	attunements = list(
-		/datum/attunement/earth = 0.3,
-	)
-
 	invocation = "Stay sharp and strong."
 	invocation_type = "whisper" //can be none, whisper, emote and shout
 	var/magic_color = "#c8daff"

--- a/code/modules/spells/spell_types/wizard/utility/encode_thoughts.dm
+++ b/code/modules/spells/spell_types/wizard/utility/encode_thoughts.dm
@@ -21,7 +21,7 @@
 	miracle = FALSE
 
 	invocation = ""
-	invocation_type = "shout" //can be none, whisper, emote and shout
+	invocation_type = "none" //can be none, whisper, emote and shout
 	include_user = FALSE
 
 

--- a/code/modules/spells/spell_types/wizard/utility/encode_thoughts.dm
+++ b/code/modules/spells/spell_types/wizard/utility/encode_thoughts.dm
@@ -24,9 +24,6 @@
 	invocation_type = "shout" //can be none, whisper, emote and shout
 	include_user = FALSE
 
-	attunements = list(
-		/datum/attunement/dark = 0.5,
-	)
 
 /obj/effect/proc_holder/spell/targeted/encodethoughts5e/cast(list/targets, mob/user)
 	. = ..()

--- a/code/modules/spells/spell_types/wizard/utility/ensnare.dm
+++ b/code/modules/spells/spell_types/wizard/utility/ensnare.dm
@@ -15,12 +15,9 @@
 	associated_skill = /datum/skill/magic/arcane
 	range = 6
 	overlay_state = "ensnare"
-	attunements = list(
-		/datum/attunement/time = 0.3,
-		/datum/attunement/arcyne = 0.4,
-	)
+
 	var/area_of_effect = 1
-	var/duration = 4 SECONDS
+	var/duration = 8 SECONDS
 	var/delay = 0.8 SECONDS
 
 /obj/effect/proc_holder/spell/invoked/slowdown_spell_aoe/cast(list/targets, mob/user = usr)

--- a/code/modules/spells/spell_types/wizard/utility/fetch.dm
+++ b/code/modules/spells/spell_types/wizard/utility/fetch.dm
@@ -15,9 +15,6 @@
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/arcane
 	cost = 2
-	attunements = list(
-		/datum/attunement/aeromancy = 0.3,
-	)
 
 /obj/projectile/magic/fetch/on_hit(target)
 	. = ..()

--- a/code/modules/spells/spell_types/wizard/utility/forcewall.dm
+++ b/code/modules/spells/spell_types/wizard/utility/forcewall.dm
@@ -19,9 +19,6 @@
 	associated_skill = /datum/skill/magic/arcane
 	var/wall_type = /obj/structure/forcefield_weak/caster
 	cost = 3
-	attunements = list(
-		/datum/attunement/illusion = 0.3,
-	)
 
 //adapted from forcefields.dm, this needs to be destructible
 /obj/structure/forcefield_weak

--- a/code/modules/spells/spell_types/wizard/utility/light.dm
+++ b/code/modules/spells/spell_types/wizard/utility/light.dm
@@ -17,15 +17,10 @@
 	associated_skill = /datum/skill/magic/arcane //can be arcane, druidic, blood, holy
 	cost = 1
 
-
 	miracle = FALSE
 
 	invocation = "Let there be light."
 	invocation_type = "whisper" //can be none, whisper, emote and shout
-
-	attunements = list(
-		/datum/attunement/light = 0.3,
-	)
 
 	var/obj/item/item
 	var/item_type = /obj/item/flashlight/flare/light5e

--- a/code/modules/spells/spell_types/wizard/utility/mending.dm
+++ b/code/modules/spells/spell_types/wizard/utility/mending.dm
@@ -20,9 +20,7 @@
 	miracle = FALSE
 
 	invocation = ""
-	attunements = list(
-		/datum/attunement/life = 1.2
-	)
+
 	invocation_type = "shout" //can be none, whisper, emote and shout
 
 /obj/effect/proc_holder/spell/invoked/mending/cast(list/targets, mob/living/user)

--- a/code/modules/spells/spell_types/wizard/utility/mimicry.dm
+++ b/code/modules/spells/spell_types/wizard/utility/mimicry.dm
@@ -11,10 +11,7 @@
 	movement_interrupt = FALSE
 	sound = 'sound/misc/area.ogg'
 	associated_skill = /datum/skill/magic/arcane
-	attunements = list(
-		/datum/attunement/dark = 0.4,
-		/datum/attunement/polymorph = 1.2,
-		)
+
 	var/datum/dna/old_dna
 	var/old_hair
 	var/old_hair_color

--- a/code/modules/spells/spell_types/wizard/utility/poison_spray.dm
+++ b/code/modules/spells/spell_types/wizard/utility/poison_spray.dm
@@ -1,6 +1,6 @@
 /obj/effect/proc_holder/spell/invoked/poisonspray5e
-	name = "Poison Cloud" //renamed to better reflect wtf this does -- vide
-	desc = "Hold a container in your hand, it's contents turn into a 3-radius smoke"
+	name = "Aresolize" //renamed to better reflect wtf this does -- vide
+	desc = "Hold a container in your hand, it's contents turn intoing a cloud covering a three by three square."
 	overlay_state = "null"
 	releasedrain = 50
 	chargetime = 3
@@ -25,7 +25,7 @@
 
 	miracle = FALSE
 
-	invocation = "Poison Cloud!"
+	invocation = "Evaporate!"
 	invocation_type = "shout" //can be none, whisper, emote and shout
 
 /obj/effect/proc_holder/spell/invoked/poisonspray5e/cast(list/targets, mob/living/user)

--- a/code/modules/spells/spell_types/wizard/utility/poison_spray.dm
+++ b/code/modules/spells/spell_types/wizard/utility/poison_spray.dm
@@ -18,11 +18,6 @@
 	associated_skill = /datum/skill/magic/arcane //can be arcane, druidic, blood, holy
 	cost = 1
 
-	attunements = list(
-		/datum/attunement/blood = 0.3,
-		/datum/attunement/death = 0.3,
-	)
-
 	miracle = FALSE
 
 	invocation = "Evaporate!"

--- a/code/modules/spells/spell_types/wizard/utility/prestidigitation.dm
+++ b/code/modules/spells/spell_types/wizard/utility/prestidigitation.dm
@@ -16,9 +16,6 @@
 	associated_skill = /datum/skill/magic/arcane
 	hand_path = /obj/item/melee/touch_attack/prestidigitation
 	cost = 1
-	attunements = list(
-		/datum/attunement/arcyne = 0.2,
-	)
 
 /obj/item/melee/touch_attack/prestidigitation
 	name = "\improper prestidigitating touch"

--- a/code/modules/spells/spell_types/wizard/utility/repel.dm
+++ b/code/modules/spells/spell_types/wizard/utility/repel.dm
@@ -16,9 +16,6 @@
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/arcane
 	cost = 2
-	attunements = list(
-		/datum/attunement/aeromancy = 0.6,
-	)
 
 /obj/effect/proc_holder/spell/invoked/projectile/repel/fire_projectile(mob/living/user, atom/target)
 	if(iscarbon(user))

--- a/code/modules/spells/spell_types/wizard/utility/repulse.dm
+++ b/code/modules/spells/spell_types/wizard/utility/repulse.dm
@@ -65,9 +65,7 @@
 	charging_slowdown = 2
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/arcane
-	attunements = list(
-		/datum/attunement/aeromancy = 0.4,
-	)
+
 	var/stun_amt = 5
 	var/maxthrow = 3
 	var/sparkle_path = /obj/effect/temp_visual/gravpush

--- a/code/modules/spells/spell_types/wizard/utility/shadow_step.dm
+++ b/code/modules/spells/spell_types/wizard/utility/shadow_step.dm
@@ -11,9 +11,7 @@
 	movement_interrupt = FALSE
 	sound = 'sound/misc/area.ogg'
 	associated_skill = /datum/skill/misc/sneaking
-	attunements = list(
-		/datum/attunement/dark = 0.4
-		)
+
 	cost = 1
 
 /obj/effect/proc_holder/spell/invoked/shadowstep/cast(list/targets, mob/living/user)

--- a/vanderlin.dme
+++ b/vanderlin.dme
@@ -1731,7 +1731,6 @@
 #include "code\modules\crafting\artificer\_base.dm"
 #include "code\modules\crafting\artificer\misc.dm"
 #include "code\modules\crafting\book_entries\_base.dm"
-#include "code\modules\crafting\book_entries\attunement_matrix.dm"
 #include "code\modules\crafting\book_entries\container_craft.dm"
 #include "code\modules\crafting\book_entries\grimoire.dm"
 #include "code\modules\crafting\book_entries\mana_sources.dm"


### PR DESCRIPTION
Major changes first

Overhaul of the Spellbook: Spells are now ordered by offensive (sorted further by rough elements), to buffs, to utilty.

removal of attunments: Magic in lore consists of two (and maybe more!) paths. Of the two avaliable currently, Noccian magic is more traditional "I cast firebolt!", while Zizian magic is based around rituals and fleshcrafting.

NO OTHER PATREONS ALLOW FOR MAGIC RIGHT NOW. THESE ARE THE ONLY TWO PATHS WHICH CAN BE TREAD BY MOST MORTALS

As such, attunements don't make sense. Why does it matter what your patron is, when your only being able to use magic if your noc OR zizo. Why would you be attunted to a element, when you either are able to access the Acryne, or you are not?

Mage Apprentice is now forced into Noc or Zizo. If your not either when you roll it, your going gambling between the snooty prick and the genocidal scientist.

You can no longer learn magic if you do not have it round start. (This I do need help with coding in)

Shifts to spell costs. If you want Acryne storm, it's now 8 SP. Chill Touch is now 4, lighting is now 6. other adjustments will be made as the community eveitably puts feedback here.

Some spells (especially redudant ones) have been removed from the spellbook learn list, but still exist in code.

You can no longer learn Meteor swarm. This will be added as a choice for court mage. Either you know Meteor, or you know Jaunt and Knock.

Minor Changes:

Posion Cloud has been renamed to be more reflective of what it does.

Some spells which were unclear with their descriptions have also been changed to help players understand what they are casting and what's it gonna do.
Why It's Good For The Game

Magic is in a weird state since SnS. We have a few redundent spells, a series of spells which are balanced horribly (Acryne Storm costs 2 points and does 150 points of damage over a period of 15 seconds. It's Too Good. Chill touch costs ONE spell point, and yet you can pretty easily overwhelm someone with skeletal hands. Two lighting bolts allow for easy stunlocks, ect). Aberra gave me the green light to change some stuff, so I have. A few of these changes are ment to bring magic in line with the lore (Attunement Removal, Restriction of Patrons, difficulty of Noccian Magic), and the others are meant to put mages back in a balanced state.

These values are a starting place, I am relying on the angry magic nerds who willl come into the replies to help balance it a bit better. The general idea is to move offensive/lethal magic to cost more, but have buffs/ultility magic cost less. Keep in mind. I will do a follow up PR that adds a few new spells to make up for what's being lost.

Hard nos:

Your not getting meteor back. Don't even ask.

Same with blood bolt (i dont know why this was made learnable anyhow. It's blood magic, not arcyne.)

No reduction of combat spells below 2 points.

No patrons other than Noc or Zizo as magic roles. I've been pestering Aberra here. Her stance is clear. We're only getting Noc and Zizo in these roles.
## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
